### PR TITLE
Added optional POST callback

### DIFF
--- a/lotify/client.py
+++ b/lotify/client.py
@@ -30,7 +30,7 @@ class Client:
                f"redirect_uri={self.redirect_uri}, bot_origin={self.bot_origin}, " \
                f"api_origin={self.api_origin}>"
 
-    def get_auth_link(self, state):
+    def get_auth_link(self, state,form_post=False):
         query_string = {
             'scope': 'notify',
             'response_type': 'code',
@@ -38,6 +38,7 @@ class Client:
             'redirect_uri': self.redirect_uri,
             'state': state
         }
+        if form_post:query_string.update({'response_mode':'form_post'})
         return '{url}/oauth/authorize?{query_string}'.format(
             url=self.bot_origin, query_string=urlencode(query_string))
 


### PR DESCRIPTION
- Added an optional paramater for `get_auth_link` generator  function, to allow `response_mode=form_post` as an optional query parameter
- This allows LINE Notify server to directly send POST request to callback URL instead of URL redirection

From API docs:	
By assigning "form_post", sends POST request to redirect_uri by form post instead of redirecting
Extended specifications: https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html

We recommend assigning this to prevent code parameter leaks in certain environments