### PR TITLE
feat: Support sticker message and check status api in cli

### DIFF
--- a/lotify/cli.py
+++ b/lotify/cli.py
@@ -12,15 +12,24 @@ def cli():
 
 @cli.command()
 @click.option('-t', '--access_token', type=str, help='LINE Notify access token', required=True)
-@click.option('-m', '--message', type=str, help='send text message', required=True)
+@click.option('-m', '--message', type=str, help='send text message')
 @click.option('-u', '--image-url', type=str, help='Send image with image url', default=None)
 @click.option('-f', '--image-file', type=str, help='Send image file with local file', default=None)
-def send_message(message, access_token, image_url, image_file):
+@click.option('--sticker-package-id', type=str, help='Sticker package id', default=None)
+@click.option('--sticker-id', type=str, help='Sticker id', default=None)
+@click.option('-c', '--check-status', is_flag=True, help='Check status', default=False)
+def send_message(message, access_token, image_url, image_file,
+                 sticker_package_id, sticker_id, check_status):
     client = Client()
+    if check_status:
+        status = client.status(access_token)
+        click.echo("Status: {status}".format(status=status))
     if image_url is not None:
         client.send_message_with_image_url(access_token, message, image_url, image_url)
     elif image_file is not None:
         client.send_message_with_image_file(access_token, message, open(image_file, 'rb'))
+    elif sticker_package_id is not None and sticker_id is not None:
+        client.send_message_with_sticker(access_token, message, sticker_id, sticker_package_id)
     else:
         client.send_message(access_token, message)
     click.echo("Send notification success.")

--- a/lotify/client.py
+++ b/lotify/client.py
@@ -17,7 +17,6 @@ class Client:
                  bot_origin=None,
                  api_origin=None,
                  *args, **kwargs):
-        super(Client, self).__init__(*args, **kwargs)
         self.client_id = client_id or self.CLIENT_ID
         self.client_secret = client_secret or self.CLIENT_SECRET
         self.redirect_uri = redirect_uri or self.REDIRECT_URI
@@ -86,8 +85,8 @@ class Client:
             notification_disabled=False):
         params = {
             'message': message,
-            'stickerId': sticker_id,
-            'stickerPackageId': sticker_package_id
+            'stickerPackageId': sticker_package_id,
+            'stickerId': sticker_id
         }
         if notification_disabled:
             params.update({'notificationDisabled': notification_disabled})
@@ -96,7 +95,8 @@ class Client:
             url='{url}/api/notify'.format(url=self.api_origin),
             data=params,
             headers={
-                'Authorization': 'Bearer {token}'.format(token=access_token)
+                'Authorization': 'Bearer {token}'.format(token=access_token),
+                'Content-Type': 'application/x-www-form-urlencoded'
             })
         return response.json()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,98 @@
+import unittest
+import responses
+from unittest.mock import patch
+from click.testing import CliRunner
+from lotify.cli import send_message
+
+
+class TestCli(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+        self.token = 'YgVGZjHTprZdsooj5xOGXBl9vVwLGBEbjyjaBWY1Mbe'
+        self.bot_origin = "https://notify-bot.line.me"
+        self.api_origin = "https://notify-api.line.me"
+
+    @responses.activate
+    @patch('lotify.client.Client')
+    def test_check_status(self, mock_client):
+        responses.add(
+            responses.GET,
+            '{url}/api/status'.format(url=self.api_origin),
+            json={
+                'status': 200,
+                'message': 'ok'
+            },
+            status=200
+        )
+        mock_client.status.return_value = {'status': 200, 'message': 'ok'}
+        result = self.runner.invoke(send_message, ['--check-status', '--access_token', self.token])
+        self.assertEqual(result.output, "Status: {'status': 200, 'message': 'ok'}\n")
+
+    @responses.activate
+    @patch('lotify.client.Client')
+    def test_send_message(self, mock_client):
+        responses.add(
+            responses.POST,
+            '{url}/api/notify'.format(url=self.api_origin),
+            json={
+                'status': 200,
+                'message': 'ok'
+            },
+            status=200
+        )
+        mock_client.send_message.return_value = {'status': 200, 'message': 'ok'}
+        result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello'])
+        self.assertEqual(result.output, "Send notification success.\n")
+
+    @responses.activate
+    @patch('lotify.client.Client')
+    def test_send_image_with_image_url(self, mock_client):
+        responses.add(
+            responses.POST,
+            '{url}/api/notify'.format(url=self.api_origin),
+            json={
+                'status': 200,
+                'message': 'ok'
+            },
+            status=200
+        )
+        mock_client.send_message_with_image_url.return_value = {'status': 200, 'message': 'ok'}
+        result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello', '--image-url', 'https://example.com/image.png'])
+        self.assertEqual(result.output, "Send notification success.\n")
+
+    @responses.activate
+    @patch('lotify.client.Client')
+    def test_send_image_with_image_file(self, mock_client):
+        responses.add(
+            responses.POST,
+            '{url}/api/notify'.format(url=self.api_origin),
+            json={
+                'status': 200,
+                'message': 'ok'
+            },
+            status=200
+        )
+
+        with self.runner.isolated_filesystem():
+            with open('image.png', 'w') as f:
+                f.write('This is file object')
+            mock_client.send_message_with_image_file.return_value = {'status': 200, 'message': 'ok'}
+            result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello', '--image-file', 'image.png'])
+
+        self.assertEqual(result.output, "Send notification success.\n")
+
+    @responses.activate
+    @patch('lotify.client.Client')
+    def test_send_sticker_message(self, mock_client):
+        responses.add(
+            responses.POST,
+            '{url}/api/notify'.format(url=self.api_origin),
+            json={
+                'status': 200,
+                'message': 'ok'
+            },
+            status=200
+        )
+        mock_client.send_sticker_message.return_value = {'status': 200, 'message': 'ok'}
+        result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello', '--sticker-package-id', '1', '--sticker-id', '1'])
+        self.assertEqual(result.output, "Send notification success.\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,91 +8,118 @@ from lotify.cli import send_message
 class TestCli(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
-        self.token = 'YgVGZjHTprZdsooj5xOGXBl9vVwLGBEbjyjaBWY1Mbe'
+        self.token = "YgVGZjHTprZdsooj5xOGXBl9vVwLGBEbjyjaBWY1Mbe"
         self.bot_origin = "https://notify-bot.line.me"
         self.api_origin = "https://notify-api.line.me"
 
     @responses.activate
-    @patch('lotify.client.Client')
+    @patch("lotify.client.Client")
     def test_check_status(self, mock_client):
         responses.add(
             responses.GET,
-            '{url}/api/status'.format(url=self.api_origin),
-            json={
-                'status': 200,
-                'message': 'ok'
-            },
-            status=200
+            "{url}/api/status".format(url=self.api_origin),
+            json={"status": 200, "message": "ok"},
+            status=200,
         )
-        mock_client.status.return_value = {'status': 200, 'message': 'ok'}
-        result = self.runner.invoke(send_message, ['--check-status', '--access_token', self.token])
+        mock_client.status.return_value = {"status": 200, "message": "ok"}
+        result = self.runner.invoke(
+            send_message, ["--check-status", "--access_token", self.token]
+        )
         self.assertEqual(result.output, "Status: {'status': 200, 'message': 'ok'}\n")
 
     @responses.activate
-    @patch('lotify.client.Client')
+    @patch("lotify.client.Client")
     def test_send_message(self, mock_client):
         responses.add(
             responses.POST,
-            '{url}/api/notify'.format(url=self.api_origin),
-            json={
-                'status': 200,
-                'message': 'ok'
-            },
-            status=200
+            "{url}/api/notify".format(url=self.api_origin),
+            json={"status": 200, "message": "ok"},
+            status=200,
         )
-        mock_client.send_message.return_value = {'status': 200, 'message': 'ok'}
-        result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello'])
+        mock_client.send_message.return_value = {"status": 200, "message": "ok"}
+        result = self.runner.invoke(
+            send_message, ["--access_token", self.token, "--message", "Hello"]
+        )
         self.assertEqual(result.output, "Send notification success.\n")
 
     @responses.activate
-    @patch('lotify.client.Client')
+    @patch("lotify.client.Client")
     def test_send_image_with_image_url(self, mock_client):
         responses.add(
             responses.POST,
-            '{url}/api/notify'.format(url=self.api_origin),
-            json={
-                'status': 200,
-                'message': 'ok'
-            },
-            status=200
+            "{url}/api/notify".format(url=self.api_origin),
+            json={"status": 200, "message": "ok"},
+            status=200,
         )
-        mock_client.send_message_with_image_url.return_value = {'status': 200, 'message': 'ok'}
-        result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello', '--image-url', 'https://example.com/image.png'])
+        mock_client.send_message_with_image_url.return_value = {
+            "status": 200,
+            "message": "ok",
+        }
+        result = self.runner.invoke(
+            send_message,
+            [
+                "--access_token",
+                self.token,
+                "--message",
+                "Hello",
+                "--image-url",
+                "https://example.com/image.png",
+            ],
+        )
         self.assertEqual(result.output, "Send notification success.\n")
 
     @responses.activate
-    @patch('lotify.client.Client')
+    @patch("lotify.client.Client")
     def test_send_image_with_image_file(self, mock_client):
         responses.add(
             responses.POST,
-            '{url}/api/notify'.format(url=self.api_origin),
-            json={
-                'status': 200,
-                'message': 'ok'
-            },
-            status=200
+            "{url}/api/notify".format(url=self.api_origin),
+            json={"status": 200, "message": "ok"},
+            status=200,
         )
 
         with self.runner.isolated_filesystem():
-            with open('image.png', 'w') as f:
-                f.write('This is file object')
-            mock_client.send_message_with_image_file.return_value = {'status': 200, 'message': 'ok'}
-            result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello', '--image-file', 'image.png'])
+            with open("image.png", "w") as f:
+                f.write("This is file object")
+            mock_client.send_message_with_image_file.return_value = {
+                "status": 200,
+                "message": "ok",
+            }
+            result = self.runner.invoke(
+                send_message,
+                [
+                    "--access_token",
+                    self.token,
+                    "--message",
+                    "Hello",
+                    "--image-file",
+                    "image.png",
+                ],
+            )
 
         self.assertEqual(result.output, "Send notification success.\n")
 
     @responses.activate
-    @patch('lotify.client.Client')
+    @patch("lotify.client.Client")
     def test_send_sticker_message(self, mock_client):
         responses.add(
             responses.POST,
-            '{url}/api/notify'.format(url=self.api_origin),
-            json={
-                'status': 200,
-                'message': 'ok'
-            },
-            status=200
+            "{url}/api/notify".format(url=self.api_origin),
+            json={"status": 200, "message": "ok"},
+            status=200,
         )
-        mock_client.send_sticker_message.return_value = {'status': 200, 'message': 'ok'}
-        result = self.runner.invoke(send_message, ['--access_token', self.token, '--message', 'Hello', '--sticker-package-id', '1', '--sticker-id', '1'])
+        mock_client.send_sticker_message.return_value = {"status": 200, "message": "ok"}
+        result = self.runner.invoke(
+            send_message,
+            [
+                "--access_token",
+                self.token,
+                "--message",
+                "Hello",
+                "--sticker-package-id",
+                "1",
+                "--sticker-id",
+                "1",
+            ],
+        )
         self.assertEqual(result.output, "Send notification success.\n")


### PR DESCRIPTION
- [x]  Add sticker decorator and condition
- [x]  Use lotify status function
- [x]  Test cases

#11 

I removed the line super(Client, self).__init__(*args, **kwargs) because Client does not inherit from a custom superclass, making this call redundant and unnecessary for our class’s functionality.

Reference: [click.testing](https://click.palletsprojects.com/en/8.1.x/testing/)